### PR TITLE
Fix: Add key to the map function

### DIFF
--- a/src/containers/About/index.tsx
+++ b/src/containers/About/index.tsx
@@ -44,8 +44,8 @@ class About extends React.Component<any, any> {
             <StyledHr/>
           </Headline>
           <AboutSectionInner>
-            {contributors.map(contributor =>
-              <Card>
+            {contributors.map((contributor, index) =>
+              <Card key = {index}>
                 <AvatarContainer>
                   <Avatar
                     name={contributor.name}


### PR DESCRIPTION
Add index to the key value of the map function to remove unique key warning from the console.